### PR TITLE
🖍️ Customizable color style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # nofan
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/LitoMore/nofan.svg)](https://greenkeeper.io/)
+[![](https://badges.greenkeeper.io/LitoMore/nofan.svg)](https://greenkeeper.io/)
 [![](https://img.shields.io/travis/LitoMore/nofan/master.svg)](https://travis-ci.org/LitoMore/nofan)
 [![](https://img.shields.io/appveyor/ci/LitoMore/nofan/master.svg)](https://ci.appveyor.com/project/LitoMore/nofan)
 [![](https://img.shields.io/npm/v/nofan.svg)](https://www.npmjs.com/package/nofan)
 [![](https://img.shields.io/npm/l/nofan.svg)](https://github.com/LitoMore/nofan/blob/master/LICENSE)
+[![](https://img.shields.io/badge/unicorn-approved-ff69b4.svg)](https://www.youtube.com/watch?v=9auOCbH5Ns4)
 [![](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 FanFou Cli for Node.js
@@ -28,9 +29,12 @@ $ nofan login
 
 ## Usage
 
+### Commands
+
 ```bash
 $ nofan --help               # show help
 $ nofan config               # config consumer key and consumer secret
+$ nofan colors               # customize color style
 $ nofan login                # login fanfou account
 $ nofan logout               # logout current account
 $ nofan switch               # switch fanfou account
@@ -50,3 +54,65 @@ $ nofan hi -p ~/hola.png     # post status "hi" with a photo
 $ nofan home -t              # show timeline with time ago tag
 $ nofan --no-photo-tag       # show timeline whihout photo tag
 ```
+
+### Styles
+
+Use `nofan colors` to customize your color style.
+
+**Format**
+
+Use dot (`.`) to separeate multiple styles.
+
+**Example**
+
+```
+> #ff99cc
+> bold.#ff0000
+> pink.underline
+> cyanBright
+> orange.inverse.underline
+```
+
+#### Valid Styles
+
+**Modifiers**
+
+- reset
+- bold
+- dim
+- italic (Not widely supported)
+- underline
+- inverse
+- hidden
+- strikethrough (Not widely supported)
+
+**Colors**
+
+- black
+- red
+- green
+- yellow
+- blue (On Windows the bright version is used since normal blue is illegible)
+- magenta
+- cyan
+- white
+- gray ("bright black")
+- redBright
+- greenBright
+- yellowBright
+- blueBright
+- magentaBright
+- cyanBright
+- whiteBright
+
+**Hex triplet**
+
+[Hex_triplet](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) is valid.
+
+**CSS Keywords**
+
+[CSS keyword](https://www.w3.org/wiki/CSS/Properties/color/keywords) is valid.
+
+## License
+
+MIT @ [LitoMore](https://github.com/LitoMore)

--- a/bin/nofan.js
+++ b/bin/nofan.js
@@ -19,6 +19,13 @@ program
   })
 
 program
+  .command('colors')
+  .description('')
+  .action(function () {
+    Nofan.colors()
+  })
+
+program
   .command('login [username] [password]')
   .description('login nofan')
   .action(function (username, password) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nofan",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1170,11 +1170,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
       "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
     },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -1328,6 +1323,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -2109,7 +2109,7 @@
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
       "requires": {
         "iconv-lite": "0.4.18",
-        "jschardet": "1.4.2",
+        "jschardet": "1.5.0",
         "tmp": "0.0.31"
       }
     },
@@ -3572,9 +3572,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.0.tgz",
-      "integrity": "sha512-4CyUYMP7lOBkiUU1rR24WGrfRX6SucwbY2Mqb1PdApU24wnTIk4TsnkQwV72dDdIKZ2ycLP+fWCV+tA7wwgoew==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
       "requires": {
         "ansi-escapes": "2.0.0",
         "chalk": "2.0.1",
@@ -3935,9 +3935,9 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.4.2.tgz",
-      "integrity": "sha1-KqEH8UKvQSHRRWWdRPUIMJYeaZo="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.0.tgz",
+      "integrity": "sha512-+Q8JsoEQbrdE+a/gg1F9XO92gcKXgpE5UACqr0sIubjDmBEkd+OOWPGzQeMrWSLxd73r4dHxBeRW7edHu5LmJQ=="
     },
     "jsesc": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nofan",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Fanfou Cli for Node.js",
   "main": "index.js",
   "bin": "bin/nofan.js",
   "scripts": {
-    "build": "babel src -d lib",
-    "test": "npm run build && standard && ava test.js -s -v"
+    "build": "standard && babel src -d lib",
+    "test": "npm run build && ava test.js -s -v"
   },
   "repository": {
     "type": "git",
@@ -19,12 +19,13 @@
   },
   "homepage": "https://github.com/LitoMore/nofan#readme",
   "dependencies": {
-    "colors": "^1.1.2",
+    "chalk": "^2.0.1",
     "commander": "^2.9.0",
+    "css-color-names": "0.0.4",
     "fanfou-sdk": "^2.1.8",
     "figlet": "^1.2.0",
     "homedir": "^0.6.0",
-    "inquirer": "^3.0.6",
+    "inquirer": "^3.2.1",
     "timeago.js": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Styles

Use `nofan colors` to customize your color style.

**Format**

Use dot (`.`) to separeate multiple styles.

**Example**

```
> #ff99cc
> bold.#ff0000
> pink.underline
> cyanBright
> orange.inverse.underline
```

#### Valid Styles

**Modifiers**

- reset
- bold
- dim
- italic (Not widely supported)
- underline
- inverse
- hidden
- strikethrough (Not widely supported)

**Colors**

- black
- red
- green
- yellow
- blue (On Windows the bright version is used since normal blue is illegible)
- magenta
- cyan
- white
- gray ("bright black")
- redBright
- greenBright
- yellowBright
- blueBright
- magentaBright
- cyanBright
- whiteBright

**Hex triplet**

[Hex_triplet](https://en.wikipedia.org/wiki/Web_colors#Hex_triplet) is valid.

**CSS Keywords**

[CSS keyword](https://www.w3.org/wiki/CSS/Properties/color/keywords) is valid.