### PR TITLE
Add support for upload a photo from clipboard

### DIFF
--- a/bin/nofan.js
+++ b/bin/nofan.js
@@ -166,13 +166,14 @@ program
 program
   .arguments('<status> [more...]')
   .option('-p, --photo <path>', 'Attach a photo')
+  .option('-c, --clipboard', 'Use image from clipboard')
   .description('')
   .action((pre, more, options) => {
     process.spinner = ora('Sending').start()
     more.unshift(pre)
     const text = more.join(' ')
-    if (options.photo) {
-      Nofan.upload(options.photo, text)
+    if (options) {
+      Nofan.upload(options, text)
     } else {
       Nofan.update(text)
     }

--- a/src/nofan.js
+++ b/src/nofan.js
@@ -204,8 +204,14 @@ class Nofan {
     process.spinner.succeed('Sent!')
   }
 
-  static async upload (path, text) {
-    await Nofan._upload(path, text)
+  static async upload (options, text) {
+    const {photo, clipboard} = options
+    if (photo) {
+      await Nofan._upload(photo, text)
+    } else if (clipboard) {
+      const tempFilepath = await util.getTempImagePath()
+      await Nofan._upload(tempFilepath, text)
+    }
     process.spinner.succeed('Sent!')
   }
 


### PR DESCRIPTION
### Requirements

This feature only available in macOS. And it required [pngpaste](https://github.com/jcsalterego/pngpaste).

You could `brew install pngpaste` to install this dependency.

### Usage

1. Copy a image or take a screenshot to your clipboard

2. Post it

```bash
$ nofan text something -c
# Or
$ nofan text something --clipboard
```